### PR TITLE
Update benchmarks.jl

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,9 +1,5 @@
 using BenchmarkTools, TaylorModels
 
-@static if VERSION > v"0.7.0"
-    using LinearAlgebra, SparseArrays
-end
-
 SUITE = BenchmarkGroup()  # parent BenchmarkGroup to contain our suite
 
 include("daisy.jl")


### PR DESCRIPTION
Correct me if i'm wrong but i don't think that those packages are needed for `daisy.jl`. If they are, then you remove the version check, since `TaylorModels` is now meant to be used with Julia v1.0 or higher.